### PR TITLE
Adding registration model; fixed trailing whitespace, enhanced admin panel, made forms consistent with model length restrictions

### DIFF
--- a/website/meals/admin.py
+++ b/website/meals/admin.py
@@ -1,7 +1,10 @@
-from django.contrib.admin import register, StackedInline, site
+from django.contrib.admin import register, StackedInline, site, ModelAdmin
 from django.contrib.auth.models import User
 from django.contrib.auth.admin import UserAdmin
-from website.meals.models import Registrar
+from website.meals.models import Registrar, Registration
+from django.urls import reverse
+from django.utils.html import format_html
+from django.db.models import Sum
 
 # unregister User admin interface so we can redefine
 site.unregister(User)
@@ -19,7 +22,15 @@ class UserRegistrarAdmin(UserAdmin):
     """
     Admin interface for user
     """
-    list_display = ('username', 'first_name', 'last_name', 'organization', 'registration_count', 'is_staff')
+    list_display = (
+        'username',
+        'first_name',
+        'last_name',
+        'organization',
+        'registration_count',
+        'meal_count',
+        'is_staff'
+    )
     inlines = [
         RegistrarInline
     ]
@@ -29,4 +40,46 @@ class UserRegistrarAdmin(UserAdmin):
         return user.registrar.organization
 
     def registration_count(self, user):
-        return user.registrar.registration_count
+        return Registration.objects.filter(registrar=user.registrar).count()
+
+    def meal_count(self, user):
+        agg = Registration.objects.filter(registrar=user.registrar).aggregate(Sum('meal_count'))
+        return agg['meal_count__sum']
+
+
+@register(Registrar)
+class RegistrarAdmin(ModelAdmin):
+    list_display = [
+        'username',
+        'first_name',
+        'last_name',
+        'organization'
+    ]
+
+    def username(self, registrar):
+        return registrar.user.username
+
+    def first_name(self, registrar):
+        return registrar.user.first_name
+
+    def last_name(self, registrar):
+        return registrar.user.last_name
+
+
+@register(Registration)
+class RegistrationAdmin(ModelAdmin):
+    list_display = [
+        'first_name',
+        'last_name',
+        'phone',
+        'town',
+        'zip_code',
+        'address',
+        'meal_count',
+        'registered_by'
+    ]
+
+    def registered_by(self, obj):
+        link = reverse("admin:auth_user_change", args=[obj.registrar.user.id])
+        return format_html('<a href="{}"><b>{}</b></a>', link, obj.registrar.user.username)
+

--- a/website/meals/forms.py
+++ b/website/meals/forms.py
@@ -80,20 +80,20 @@ class RegistrationForm(forms.Form):
     """
     Meal registration form
     """
-    first_name = forms.CharField(required=True)
-    last_name = forms.CharField(required=True)
-    phone = PhoneField(required=True)
-    town = forms.CharField(required=True)
+    first_name = forms.CharField(required=True, max_length=100)
+    last_name = forms.CharField(required=True, max_length=100)
+    phone = PhoneField(required=True, max_length=20)
+    town = forms.CharField(required=True, max_length=100)
     zip_code = forms.CharField(
         required=True,
         max_length=5,
         min_length=5,
         validators=[validate_zip_code]
     )
-    address = forms.CharField(required=True)
-    unit = forms.CharField(required=False)
+    address = forms.CharField(required=True, max_length=100)
+    unit = forms.CharField(required=False, max_length=100)
     meal_count = forms.IntegerField(
         required=True,
         validators=[validate_meal_count]
     )
-    details = forms.CharField(required=False)
+    details = forms.CharField(required=False, max_length=1000)

--- a/website/meals/models.py
+++ b/website/meals/models.py
@@ -2,6 +2,7 @@ from django.db import models
 from django.contrib.auth.models import User
 from django.dispatch import receiver
 from django.db.models.signals import post_save
+from .forms import validate_meal_count, validate_zip_code
 
 
 class Registrar(models.Model):
@@ -10,8 +11,10 @@ class Registrar(models.Model):
     """
     user = models.OneToOneField(User, on_delete=models.CASCADE)
     organization = models.CharField(max_length=100)
-    registration_count = models.IntegerField(default=0)
     phone = models.CharField(max_length=10)
+
+    def __str__(self):
+        return self.user.username
 
 
 @receiver(post_save, sender=User)
@@ -21,3 +24,30 @@ def create_registrar(sender, instance, created, **kwargs):
     """
     if created:
         Registrar.objects.create(user=instance)
+
+
+class Registration(models.Model):
+    """
+    Model for meal registration entry
+    """
+    registrar = models.ForeignKey(Registrar, on_delete=models.CASCADE)
+
+    first_name = models.CharField(max_length=100)
+    last_name = models.CharField(max_length=100)
+
+    # currently no validator for phone number
+    phone = models.CharField(max_length=20)
+    town = models.CharField(max_length=100)
+    zip_code = models.CharField(
+        max_length=5,
+        validators=[validate_zip_code]
+    )
+    address = models.CharField(max_length=100)
+    unit = models.CharField(max_length=100)
+    meal_count = models.IntegerField(
+        validators=[validate_meal_count]
+    )
+    details = models.CharField(max_length=1000)
+
+    def __str__(self):
+        return "%s, %s (%s)" % (self.last_name, self.first_name, self.town)

--- a/website/shared/utils.py
+++ b/website/shared/utils.py
@@ -84,7 +84,7 @@ def form_to_sheets_append_body(field_order, add_ts, form=None, mock_form=None):
     # setup the values to append to the sheet
     if form:
         for key in field_order:
-            body.append(form.data[key])
+            body.append(form.cleaned_data[key])
     elif mock_form:
         for key in field_order:
             body.append(mock_form[key])


### PR DESCRIPTION
- new `Registration` model
- trailing whitespace no longer pushed to Sheets (`form.data` ->` form.cleaned_data`
- enhanced admin panel
- removed `registration_count`
- forms made consistent w/ model length restrictions
- data now saved to DB in addition to sheets